### PR TITLE
Convert PATH_TO_STATIC_FILES to str to fix TypeError

### DIFF
--- a/querychains/server.py
+++ b/querychains/server.py
@@ -14,7 +14,8 @@ from starlette.responses import FileResponse
 from . import browser
 from .storage import Storage
 
-PATH_TO_STATIC_FILES = resources.path(browser, ".")
+with resources.path(browser, ".") as static_path:
+    PATH_TO_STATIC_FILES = static_path
 
 
 class ServerHandle:


### PR DESCRIPTION
With:

```
storage = FileStorage("questions-1")
storage.start_server()
```

I was getting this error (on Python 3.11.3):
```
TypeError                                 Traceback (most recent call last)
Cell In[6], line 2
      1 storage = FileStorage("questions-1")
----> 2 storage.start_server()

File ~/projects/querychains/querychains/storage.py:67, in Storage.start_server(self, port)
     64     raise Exception("Server already started")
     65 from .server import start_server
---> 67 self._server = start_server(storage=self, port=port)
     68 return self._server

File ~/projects/querychains/querychains/server.py:114, in start_server(storage, port)
    112 def start_server(*, storage: Optional[Storage] = None, port: int = 0):
    113     handle = ServerHandle(storage=storage, port=port)
--> 114     handle.start()
    115     return handle

File ~/projects/querychains/querychains/server.py:69, in ServerHandle.start(self)
     64             return data
     66         # from IPython import embed
     67         # embed()
     68 #        with PATH_TO_STATIC_FILES as 
---> 69         app.mount("/", StaticFiles(directory=PATH_TO_STATIC_FILES), name="static")
     71         config = uvicorn.Config(app, port=self.port, log_level="error")
     72         server = uvicorn.Server(config)

File ~/Library/Caches/pypoetry/virtualenvs/querychains-GOUCAYSq-py3.11/lib/python3.11/site-packages/starlette/staticfiles.py:56, in StaticFiles.__init__(self, directory, packages, html, check_dir, follow_symlink)
     54 self.config_checked = False
     55 self.follow_symlink = follow_symlink
---> 56 if check_dir and directory is not None and not os.path.isdir(directory):
     57     raise RuntimeError(f"Directory '{directory}' does not exist")

File <frozen genericpath>:42, in isdir(s)

TypeError: stat: path should be string, bytes, os.PathLike or integer, not _GeneratorContextManager
```

importlib.resources.path returns _GeneratorContextManager. But both StaticFiles and FileResponse seems to expect String.
