### PR TITLE
Add HTMLColor helper class, with fixed pseudo-rng and lighten/darken

### DIFF
--- a/interlab/actors/actor.py
+++ b/interlab/actors/actor.py
@@ -2,7 +2,7 @@ import random
 from typing import Any
 
 from ..context import Context
-from ..utils import pseudo_random_color, shorten_str
+from ..utils import colors, shorten_str
 from . import format
 from . import memory as memory_module
 from .event import Event
@@ -24,7 +24,7 @@ class Actor:
             self.name = f"{self.__class__.__name__}{random.randint(0, 9999):i04}"
         self.style = style if style is not None else {}
         if self.style.get("color") is None:
-            self.style["color"] = pseudo_random_color(self.name)
+            self.style["color"] = str(colors.HTMLColor.random_color(self.name))
 
         # TODO: This is a bit hacky before Ada makes color variations in the UI
         self.style["fg_color"] = f'{self.style["color"]}'

--- a/interlab/utils/__init__.py
+++ b/interlab/utils/__init__.py
@@ -40,10 +40,3 @@ def generate_uid(name: str) -> str:
     uid = f"{datetime.now().isoformat(timespec='seconds')}-{name}-{random_part}"
     # Replace ':' to appease windows, and also both slashes just in case
     return uid.replace(":/\\", "-")
-
-
-def pseudo_random_color(seed: Hashable, saturation=0.5, value=1.0) -> str:
-    r, g, b = colorsys.hsv_to_rgb((hash(seed) % 256) / 255, saturation, value)
-    res = f"#{int(r * 255):02x}{int(g * 255):02x}{int(b * 255):02x}"
-    assert len(res) == 7
-    return res

--- a/interlab/utils/colors.py
+++ b/interlab/utils/colors.py
@@ -1,0 +1,130 @@
+import collections
+import colorsys
+import copy
+import random
+import re
+from typing import Any, Hashable
+
+
+class HTMLColor:
+    """Helper class representing RGB color. Accepts HTML hex notation (3, 4, 6 or 8 hex digits, with optional '#')."""
+
+    def __init__(self, color: str):
+        color = color.strip()
+        m = re.fullmatch(r"[#]?([0-9a-f]{3,8})", color.lower())
+        if not m:
+            raise ValueError(
+                f"Invalid color spec: {color!r}, expected HTML hex color spec"
+            )
+        c = m.groups()[0]
+        if len(c) not in (3, 4, 6, 8):
+            raise ValueError(
+                f"Invalid color spec: {color!r}, expected HTML hex color spec"
+            )
+        if len(c) <= 4:
+            c = "".join(2 * x for x in c)
+        self.r = int(c[0:2], base=16)
+        self.g = int(c[2:4], base=16)
+        self.b = int(c[4:6], base=16)
+        if len(c) == 8:
+            self.a = int(c[6:8], base=16)
+        else:
+            self.a = None
+
+    def as_floats(self) -> tuple:
+        "Returns (r,g,b) or (r,g,b,a), with all values 0..1"
+        cf = (self.r / 255, self.g / 255, self.b / 255)
+        if self.a is not None:
+            cf += (self.a / 255,)
+        return cf
+
+    @classmethod
+    def from_floats(cls, r: float, g: float, b: float, a: float = None) -> "HTMLColor":
+        """Returns (r,g,b) or (r,g,b,a), with all values 0.0 .. 1.0."""
+        c = cls("000000")
+        c.r = round(r * 255)
+        c.g = round(g * 255)
+        c.b = round(b * 255)
+        if a is not None:
+            c.a = round(a * 255)
+        return c
+
+    def __str__(self):
+        """Returns the color in '#RRGGBB[AA]' HTML hex format."""
+        s = f"#{self.r:02x}{self.g:02x}{self.b:02x}"
+        if self.a is not None:
+            s += f"{self.a:02x}"
+        return s
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({str(self)!r})"
+
+    def copy(self):
+        return copy.copy(self)
+
+    def _blend_lightness(self, tgt: float, rate: float) -> "HTMLColor":
+        h, l, s = colorsys.rgb_to_hls(*self.as_floats())
+        l = rate * tgt + (1 - rate) * l
+        c = self.from_floats(*colorsys.hls_to_rgb(h, l, s))
+        c.a = self.a
+        return c
+
+    def lighter(self, rate=0.2) -> "HTMLColor":
+        "Returns a lighter copy of the color: rate=1.0 returns white, rate=0 returns the same color."
+        return self._blend_lightness(1.0, rate)
+
+    def darker(self, rate=0.2) -> "HTMLColor":
+        "Returns a darker copy of the color: rate=1.0 returns black, rate=0 returns the same color."
+        return self._blend_lightness(0.0, rate)
+
+    def with_alpha(self, a: float) -> "HTMLColor":
+        "Returns a copy of the color with given alpha: float 0.0-1.0"
+        assert isinstance(a, (float, int)) and a <= 1.0 and a >= 0.0
+        c = self.copy()
+        c.a = round(a * 255)
+        return c
+
+    @classmethod
+    def random_color(
+        cls,
+        seed: Any | None = None,
+        saturation=0.7,
+        lighness=0.5,
+        *,
+        vary_lightness_rate=0.2,
+        vary_saturation_rate=0.3,
+    ) -> str:
+        """Returns a pseudo-random color for the given object, or a random color.
+
+        The color is primarily determined by a random hue and given saturation and lightness.
+        By default, the lightness and saturation of the generated color slightly varies from the given values.
+        The returned color is guaranteed to be stable across runs for string seeds (or objects with stable __repr__ value).
+        """
+        if (seed is not None) and (not isinstance(seed, str)):
+            # This can bring instability between versions of your __repr__ or Python
+            # and for some objects this may just vary even among identical objects
+            seed = repr(seed)
+            # Remove any concrete pointer addresses, as these will vary
+            seed = re.sub(f"0x[0-9a-fA-F]{8,20}", "<0xPTR>", seed)
+        rng = random.Random(seed)
+
+        hue = rng.random()
+        tgt_s = rng.random()
+        tgt_l = rng.random()
+        return cls.from_floats(
+            *colorsys.hls_to_rgb(
+                hue,
+                (1 - vary_lightness_rate) * lighness + vary_lightness_rate * tgt_l,
+                (1 - vary_saturation_rate) * saturation + vary_saturation_rate * tgt_s,
+            )
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return (
+            (self.r == other.r)
+            and (self.g == other.g)
+            and (self.b == other.b)
+            and (self.a == other.a)
+        )

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,0 +1,20 @@
+from interlab.utils.colors import HTMLColor
+
+
+def test_colors():
+    for s in ["#000000", "#00000000", "#ffffff", "#ffffffff", "#12345678", "#fedcba98"]:
+        assert str(HTMLColor(s)) == s
+    for s0, s1 in [("000", "#000000"), ("#fff1", "#ffffff11"), ("f926", "#ff992266")]:
+        assert str(HTMLColor(s0)) == s1
+
+    c = HTMLColor("#72e812")
+    assert str(c.darker(1.0)) == "#000000"
+    assert str(c.lighter(1.0)) == "#ffffff"
+    assert str(c.darker()) == "#5bba0e"
+    assert str(c.lighter()) == "#8ef03e"
+    assert str(c.with_alpha(0.5)) == "#72e81280"
+
+    # Testing hash functionality and stability
+    # NOTE: may also be unstable due to float errors
+    assert str(HTMLColor.random_color("Alice")) == "#2e49e1"
+    assert str(HTMLColor.random_color(42)) == "#25c3aa"


### PR DESCRIPTION
Intended for color manipulation for visualizations.
Fix: pseudo-random color was using `hash` which is unstable between runs. Now uses `str`s (preferred) and `repr` otherwise.