### PR TITLE
improve car_negotiation notebook by installing modules first

### DIFF
--- a/notebooks/car_negotiation.ipynb
+++ b/notebooks/car_negotiation.ipynb
@@ -13,6 +13,18 @@
    ]
   },
   {
+    "cell_type": "code",
+    "source": [
+      "!pip install python-dotenv langchain interlab"
+    ],
+    "metadata": {
+      "id": "mXY_cQyUJfXL"
+    },
+    "id": "mXY_cQyUJfXL",
+    "execution_count": null,
+    "outputs": []
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "ff3ce976-62cb-4f0b-a003-dd22df1edaa3",


### PR DESCRIPTION
I would have a look to integrate https://docs.python.org/3/library/getpass.html instead or parallel to dotenv for accessing the LLM API here, that should be easier to get started fast.